### PR TITLE
Updated program args

### DIFF
--- a/cmd/report/report.go
+++ b/cmd/report/report.go
@@ -2,13 +2,25 @@ package report
 
 import (
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	"github.com/Liu-Chunhui/line-coverage/pkg/coverage"
+	"github.com/Liu-Chunhui/line-coverage/pkg/fileparser"
 	"github.com/Liu-Chunhui/line-coverage/pkg/percentage"
 )
 
-func Report(coverprofile string, module string, basePath string) error {
-	results, err := coverage.Calculate(coverprofile, module, basePath)
+func Report(coverprofile string, gomod string) error {
+	// load module name from go.mod file
+	module, err := loadModule(gomod)
+	if err != nil {
+		return err
+	}
+
+	// load root path from go.mod file path. normally go.mod is located at the root path
+	rootPath := strings.TrimRight(gomod, filepath.Clean("go.mod"))
+
+	results, err := coverage.Calculate(coverprofile, module, rootPath)
 	if err != nil {
 		return err
 	}
@@ -25,4 +37,26 @@ func Report(coverprofile string, module string, basePath string) error {
 	fmt.Printf("Overall: %s\n", percentage.Display(overall))
 
 	return nil
+}
+
+func loadModule(gomod string) (string, error) {
+	lines, err := fileparser.ReadLines(gomod)
+	if err != nil {
+		return "", err
+	}
+
+	if len(lines) < 1 {
+		return "", fmt.Errorf("%s is not a valid go.mod file", gomod)
+	}
+
+	// validate the module name
+	found, err := fileparser.MatchPattern(lines[0], fileparser.GoModGetModuleNameRule)
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		return "", fmt.Errorf("failed to retrieve module name from file %s", gomod)
+	}
+	// "module github.com/Liu-Chunhui/line-coverage\n"
+	return strings.TrimLeft(strings.TrimSpace(lines[0]), "module "), nil
 }

--- a/main.go
+++ b/main.go
@@ -32,15 +32,9 @@ func main() {
 				Required: true,
 			},
 			&cli.StringFlag{
-				Name:     "module",
+				Name:     "gomod",
 				Aliases:  []string{"m"},
-				Usage:    "module name.(e.g. github.com/Liu-Chunhui/line-coverage)",
-				Required: true,
-			},
-			&cli.StringFlag{
-				Name:     "location",
-				Aliases:  []string{"l"},
-				Usage:    "the root level location of the files are described in the coverage profile.",
+				Usage:    "go.mod with path",
 				Required: true,
 			},
 			&cli.BoolFlag{
@@ -54,8 +48,7 @@ func main() {
 
 			err := report.Report(
 				c.String("coverprofile"),
-				c.String("module"),
-				c.String("location"),
+				c.String("gomod"),
 			)
 
 			if err != nil {

--- a/pkg/fileparser/readlines.go
+++ b/pkg/fileparser/readlines.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"regexp"
 )
 
 // ReadLines converts a file to lines.
@@ -31,7 +30,7 @@ func ReadLines(filename string, excludingPatterns ...string) ([]string, error) {
 			return nil, err
 		}
 
-		execluded, err := skipLine(line, excludingPatterns...)
+		execluded, err := MatchPattern(line, excludingPatterns...)
 		if err != nil {
 			return nil, err
 		}
@@ -42,19 +41,4 @@ func ReadLines(filename string, excludingPatterns ...string) ([]string, error) {
 	}
 
 	return lines, nil
-}
-
-func skipLine(line string, patterns ...string) (bool, error) {
-	for _, p := range patterns {
-		match, err := regexp.Match(p, []byte(line))
-		if err != nil {
-			return true, err
-		}
-
-		if match {
-			return true, nil
-		}
-	}
-
-	return false, nil
 }

--- a/pkg/fileparser/readlines_test.go
+++ b/pkg/fileparser/readlines_test.go
@@ -18,52 +18,6 @@ func TestReadLines(t *testing.T) {
 	assert.Equal(t, "\n", got[41]) // line 70 is new line
 }
 
-func TestSkipLine(t *testing.T) {
-	tests := []struct {
-		name     string
-		line     string
-		rules    []string
-		expected bool
-	}{
-		{
-			name:     "include",
-			line:     "github.com/Liu-Chunhui/line-coverage/pkg/fileparser/readlines.go:12.51,14.16 2 1\n",
-			rules:    CoverageProfileExcludingRules,
-			expected: false,
-		},
-		{
-			name:     "exclude",
-			line:     "mode: set\n",
-			rules:    CoverageProfileExcludingRules,
-			expected: true,
-		},
-		{
-			name:     "new line",
-			line:     "\n",
-			rules:    CoverageProfileExcludingRules,
-			expected: true,
-		},
-		{
-			name:     "empty line",
-			line:     "    \n",
-			rules:    CoverageProfileExcludingRules,
-			expected: true,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got, err := skipLine(tt.line, tt.rules...)
-			require.NoError(t, err)
-			assert.Equal(t, tt.expected, got)
-		})
-	}
-}
-
 var testcodefile = `package fileparser
 
 import (

--- a/pkg/fileparser/rule.go
+++ b/pkg/fileparser/rule.go
@@ -1,8 +1,27 @@
 package fileparser
 
+import "regexp"
+
 var (
 	CoverageProfileExcludingRules = []string{
 		`^\s*$`,     // empty line
 		`^mode: .*`, // first line
 	}
+
+	GoModGetModuleNameRule = "^module .*" // first line is the module name
 )
+
+func MatchPattern(line string, patterns ...string) (bool, error) {
+	for _, p := range patterns {
+		match, err := regexp.Match(p, []byte(line))
+		if err != nil {
+			return true, err
+		}
+
+		if match {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/fileparser/rule_test.go
+++ b/pkg/fileparser/rule_test.go
@@ -1,0 +1,54 @@
+package fileparser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkipLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		rules    []string
+		expected bool
+	}{
+		{
+			name:     "include",
+			line:     "github.com/Liu-Chunhui/line-coverage/pkg/fileparser/readlines.go:12.51,14.16 2 1\n",
+			rules:    CoverageProfileExcludingRules,
+			expected: false,
+		},
+		{
+			name:     "exclude",
+			line:     "mode: set\n",
+			rules:    CoverageProfileExcludingRules,
+			expected: true,
+		},
+		{
+			name:     "new line",
+			line:     "\n",
+			rules:    CoverageProfileExcludingRules,
+			expected: true,
+		},
+		{
+			name:     "empty line",
+			line:     "    \n",
+			rules:    CoverageProfileExcludingRules,
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := MatchPattern(tt.line, tt.rules...)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
changes:
- removed `module` and location from program args.
- added `gomod(-m)` to args.

from `gomod` with path, we are able to retrieve module name and root code path