### PR TITLE
fixed - handle the adjustment when ending with '})' 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,6 @@ COVER_HTML?=./gen/coverage.html
 .PHONY: test
 test:
 	@mkdir -p gen  ## Creating a gen folder if it doesn't exist
-	go test `go list ./... | grep -vE "./test"` -race -covermode=atomic -coverprofile=$(COVERFILE)
+	go test `go list ./... | grep -vE "/test/"` -race -covermode=atomic -coverprofile=$(COVERFILE)
 	go tool cover -func=$(COVERFILE) 
 	go tool cover -html=$(COVERFILE) -o $(COVER_HTML)

--- a/pkg/coverage/codebranch.go
+++ b/pkg/coverage/codebranch.go
@@ -92,15 +92,25 @@ func startEmptyLineAdjustment(codeInLines []string, startLine int, adjustment in
 func finishLineAdjustment(codeInLines []string, finishLine int, position int) int {
 	statement := strings.TrimSpace(codeInLines[finishLine-1][0:position]) // trim "\t", " ", "\n"
 	statement = strings.ReplaceAll(statement, "}", "")
+	const noNeedAdjustment = 0
+
+	if statement == ")" {
+		// to check if current '}' closing for 'struct' or 'function'
+		previousLine := strings.TrimSpace(codeInLines[finishLine-2]) // trim "\t", " ", "\n"
+		if previousLine[len(previousLine)-1] == ',' {
+			return noNeedAdjustment
+		}
+		return adjustBackwards(codeInLines, finishLine-1, 1)
+	}
 
 	if statement == "" ||
 		statement == "(" ||
 		statement == "()" ||
-		statement == "," {
+		statement == "," { // When finish position is '},' then need to adjust backwards
 		return adjustBackwards(codeInLines, finishLine-1, 1)
 	}
 
-	return 0
+	return noNeedAdjustment
 }
 
 func adjustBackwards(codeInLines []string, finishLine int, adjustment int) int {
@@ -109,8 +119,7 @@ func adjustBackwards(codeInLines []string, finishLine int, adjustment int) int {
 
 	if line == "" ||
 		line == "(" ||
-		line == "()" ||
-		line == "," {
+		line == "()" {
 		return adjustBackwards(codeInLines, finishLine-1, adjustment+1)
 	}
 

--- a/pkg/coverage/codebranch_test.go
+++ b/pkg/coverage/codebranch_test.go
@@ -230,16 +230,6 @@ func TestFinishLineAdjustment(t *testing.T) {
 			expectedAdjustment: 2,
 		},
 		{
-			name: "WhenEndWithNothingBut'})'_ThenReturnNoAdjustment",
-			lines: []string{
-				"	return some code here\n",
-				"\t})\n"},
-			finishLine:         2,
-			endPos:             3,
-			expectedChar:       ')',
-			expectedAdjustment: 0,
-		},
-		{
 			name: "WhenEndWithNothingBut'}()'_ThenReturnExpectedAdjustment",
 			lines: []string{
 				"	return some code here\n",
@@ -268,6 +258,38 @@ func TestFinishLineAdjustment(t *testing.T) {
 			finishLine:         2,
 			endPos:             4,
 			expectedChar:       ',',
+			expectedAdjustment: 1,
+		},
+		{
+			name: "WhenEndWith'}'AndPreviousLineIs'},'_ThenReturnExpectedAdjustment",
+			lines: []string{
+				"\t\t\t},\n",
+				"\t\t}\n"},
+			finishLine:         2,
+			endPos:             4,
+			expectedChar:       '\n',
+			expectedAdjustment: 1,
+		},
+		{
+			// '}' closes for 'struct {'
+			name: "WhenEndWith'})AndPreviousLineEndWith','_ThenReturnNoAdjustment",
+			lines: []string{
+				"\t\t some code,\n",
+				"\t})\n"},
+			finishLine:         2,
+			endPos:             3,
+			expectedChar:       ')',
+			expectedAdjustment: 0,
+		},
+		{
+			// '}' closes for 'function {'
+			name: "WhenEndWith'})AndPreviousLineNotEndWith','_ThenReturnExpectedAdjustment",
+			lines: []string{
+				"	return some code here\n",
+				"\t})\n"},
+			finishLine:         2,
+			endPos:             3,
+			expectedChar:       ')',
 			expectedAdjustment: 1,
 		},
 	}


### PR DESCRIPTION
and previous line is part of 'struct' or 'function'
