### PR TITLE
Upgrade Go from 1.19 to 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        golang: [1.19.x]
+        golang: [1.24.x]
     steps:
       - uses: actions/checkout@v4
       - name: Install Go
@@ -27,7 +27,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        golang: [1.19.x]
+        golang: [1.24.x]
     env:
       OS: macos-latest
       GOLANG: ${{ matrix.golang }}
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        golang: [1.19.x]
+        golang: [1.24.x]
     env:
       OS: ubuntu-latest
       GOLANG: ${{ matrix.golang }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG             BUILD_ARG_VERSION=latest
 
 # build
-FROM            golang:1.19.3-alpine as builder
+FROM            golang:1.24-alpine as builder
 ARG             BUILD_ARG_VERSION
 RUN             apk add --no-cache git gcc musl-dev make
 ENV             GO111MODULE=on

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Liu-Chunhui/line-coverage
 
-go 1.19
+go 1.24
 
 require (
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
- go.mod: go 1.19 → go 1.24
- Dockerfile: golang:1.19.3-alpine → golang:1.24-alpine
- ci.yml: matrix golang 1.19.x → 1.24.x (all three jobs)
- go mod tidy: refresh go.sum for new toolchain


Fixes # ...

## Description

This PR includes the following changes ...

## Acceptance Criteria

Issue criteria: 
 - [ ] A
 - [ ] B
